### PR TITLE
Fixed the MenuItem style in Windows 8.

### DIFF
--- a/SuperbEdit/Views/ShellView.xaml
+++ b/SuperbEdit/Views/ShellView.xaml
@@ -7,7 +7,7 @@
         Icon="/SuperbEdit;component/Assets/icon.ico">
     <Window.Resources>
         <ResourceDictionary>
-            <Style TargetType="{x:Type MenuItem}" x:Key="MenuItemStyle">
+            <Style TargetType="{x:Type MenuItem}" x:Key="MenuItemStyle" BasedOn="{StaticResource {x:Type MenuItem}}">
                 <Setter Property="Header" Value="{Binding Path=Name}" />
                 <Setter Property="ToolTip" Value="{Binding Path=Description}" />
                 <Setter Property="cal:Message.Attach" Value="[Event Click] = [Action Execute()]" />


### PR DESCRIPTION
Hi. Finally found the problem.

It looks like you've overwritten the whole style of the menu item and didn't inherit the base one. So, the fix is pretty simple. But it wasn't simple to find the problem :).

Don't ask why this reproduces only on W8, I don't know :).
